### PR TITLE
Setup Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+dist: trusty
+
+language: go
+go:
+  - "1.9"
+  - "master"
+
+install:
+  - gem install --no-ri --no-rdoc fpm
+  - fpm --version
+  - go get -u github.com/golang/dep/cmd/dep
+
+deploy:
+  provider: releases
+  script: "make deb"
+  api_key:
+    secure: VFwX7jpFuf5UZFO55GCjfkCc0bQ4H0YL3iZWIh44hX0Enjx9E70xRfzFKHMlAbvK2sPTARroAlg51EwmIIdHBGZubEGUuOC2GbxmdS69qXUIBq2CD37seEq8Hpw5E2PouZlOmYiRJyRdt/c2MkNMsd5CFERUlccLm0PPORbXBWaD7J0z7PEIAXFdsdv4tfMeHoxjQZdcn/FUQctt5EG53m5HavU9uXhN9yZAz3cP9WifIVY9onEZmrypdUnJyRaMoom9Zf7ClsN1MXjJkf0Y09ZR+WPragglRqYjLnkNs9MKpdHB59Al+oZ6Ay3r398v5vEwgfNEl1xYmlKZSqaqMUd7DKKPlpLrkOFoQH2inP76VKEO/j7rZkelWrqnM78Zxeu67QOJ5JWqKHPslQRHIENRnb9Fz2zQcFBSxspeswl0TmYMvsIxUlZaArfpgIO8ytLTzf5UiazIaGsWko0zuHFhRIluywaeW0RMuDPBmpSXI12lLugo7xMZYKVdd7egTnHdh1QP2jliS4XPKjLbadWnqUk9XqALUjnrwnSXT6+tkIj+9inEM6lkVaGSTXKEyX518SWlTI7mW/SAxuXQJdj++7+mIATDXJsO2LrnFAp/Azhb++URSdjhYZ2rK1FTniytx9XzCmhgUJLL09+4gXjs1tVW6lvVdJy8tUPqAaQ=
+  file_glob: true
+  file:
+    - f3
+    - f3-server*.deb
+  on:
+    tags: true
+    repo: spreadshirt/f3

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ dist: trusty
 
 language: go
 go:
-  - "1.9"
-  - "master"
+  - 1.9
 
 install:
   - gem install --no-ri --no-rdoc fpm

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # f3
 
+[![Build Status](https://travis-ci.org/spreadshirt/f3.svg?branch=master)](https://travis-ci.org/spreadshirt/f3)
+
 f3 is a bridge that acts like an FTP server which accepts files but transfers them into an s3 bucket, instead of writing them to disk.
 
 ## Installation


### PR DESCRIPTION
This uses the default build job that is `make` and will deploy release
artifacts to github releases for git tags.
A Travis CI badge showing master build state was added to the README as
well.