### PR TITLE
Fix travis debian package upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,11 @@ install:
   - fpm --version
   - go get -u github.com/golang/dep/cmd/dep
 
+before_deploy:
+  - 'make deb'
+
 deploy:
   provider: releases
-  script: "make deb"
   api_key:
     secure: VFwX7jpFuf5UZFO55GCjfkCc0bQ4H0YL3iZWIh44hX0Enjx9E70xRfzFKHMlAbvK2sPTARroAlg51EwmIIdHBGZubEGUuOC2GbxmdS69qXUIBq2CD37seEq8Hpw5E2PouZlOmYiRJyRdt/c2MkNMsd5CFERUlccLm0PPORbXBWaD7J0z7PEIAXFdsdv4tfMeHoxjQZdcn/FUQctt5EG53m5HavU9uXhN9yZAz3cP9WifIVY9onEZmrypdUnJyRaMoom9Zf7ClsN1MXjJkf0Y09ZR+WPragglRqYjLnkNs9MKpdHB59Al+oZ6Ay3r398v5vEwgfNEl1xYmlKZSqaqMUd7DKKPlpLrkOFoQH2inP76VKEO/j7rZkelWrqnM78Zxeu67QOJ5JWqKHPslQRHIENRnb9Fz2zQcFBSxspeswl0TmYMvsIxUlZaArfpgIO8ytLTzf5UiazIaGsWko0zuHFhRIluywaeW0RMuDPBmpSXI12lLugo7xMZYKVdd7egTnHdh1QP2jliS4XPKjLbadWnqUk9XqALUjnrwnSXT6+tkIj+9inEM6lkVaGSTXKEyX518SWlTI7mW/SAxuXQJdj++7+mIATDXJsO2LrnFAp/Azhb++URSdjhYZ2rK1FTniytx9XzCmhgUJLL09+4gXjs1tVW6lvVdJy8tUPqAaQ=
   skip_cleanup: true

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,6 @@ deb: f3 test
 		--prefix /\
 		--description 'An FTP to AWS s3 bridge'\
 		--url "$(NAMESPACE)"\
-		--deb-systemd 'deb/lib/systemd/system/f3-server.service'\
 		--no-deb-systemd-restart-after-upgrade\
 		--chdir deb
 


### PR DESCRIPTION
This fixes the following exception:

```
/home/travis/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/fileutils.rb:1459:in `block in fu_each_src_dest': same file: /home/travis/gopath/src/github.com/spreadshirt/f3/deb/lib/systemd/system/f3-server.service and /tmp/package-dir-staging-b29f5bce213858b84f5eee71ba5420bdd09b0e34fae21c4c7e48550de12b/lib/systemd/system/f3-server.service (ArgumentError)
	from /home/travis/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/fileutils.rb:1476:in `fu_each_src_dest0'
	from /home/travis/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/fileutils.rb:1458:in `fu_each_src_dest'
	from /home/travis/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/fileutils.rb:355:in `cp'
	from /home/travis/.rvm/gems/ruby-2.4.1/gems/fpm-1.9.3/lib/fpm/package/deb.rb:429:in `block in output'
	from /home/travis/.rvm/gems/ruby-2.4.1/gems/fpm-1.9.3/lib/fpm/package/deb.rb:425:in `each'
	from /home/travis/.rvm/gems/ruby-2.4.1/gems/fpm-1.9.3/lib/fpm/package/deb.rb:425:in `output'
	from /home/travis/.rvm/gems/ruby-2.4.1/gems/fpm-1.9.3/lib/fpm/command.rb:487:in `execute'
	from /home/travis/.rvm/gems/ruby-2.4.1/gems/clamp-1.0.1/lib/clamp/command.rb:68:in `run'
	from /home/travis/.rvm/gems/ruby-2.4.1/gems/fpm-1.9.3/lib/fpm/command.rb:574:in `run'
	from /home/travis/.rvm/gems/ruby-2.4.1/gems/clamp-1.0.1/lib/clamp/command.rb:133:in `run'
	from /home/travis/.rvm/gems/ruby-2.4.1/gems/fpm-1.9.3/bin/fpm:8:in `<top (required)>'
	from /home/travis/.rvm/gems/ruby-2.4.1/bin/fpm:23:in `load'
	from /home/travis/.rvm/gems/ruby-2.4.1/bin/fpm:23:in `<main>'
	from /home/travis/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `eval'
	from /home/travis/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `<main>'
make: *** [deb] Error 1
```

If have absolutely no clue what the intention of the `--deb-systemd`
option is because the script is still included in the package at the
correct path even without this option:

```sh
$ make deb &&  ar x f3-server_0.3.8_amd64.deb data.tar.gz &&  tar --list -f data.tar.gz | grep f3-server.service
./lib/systemd/system/f3-server.service
```